### PR TITLE
Add Stithulf ERC to IceCream Swap

### DIFF
--- a/bsc.json
+++ b/bsc.json
@@ -218,6 +218,14 @@
       "symbol": "1INCH",
       "decimals": 18,
       "logoURI": "https://bscscan.com/token/images/1inch_32.png"
+    },
+    {
+      "address": "0x9df9de5ed89adbbd9fa2c14691903a0de9048a87",
+      "chainId": 56,
+      "name": "Stithulf ERC",
+      "symbol": "SULFERC",
+      "decimals": 4,
+      "logoURI": "https://bscscan.com/token/images/stithulf_32.png"
     }
   ]
 }


### PR DESCRIPTION
Stithulf ERC is over an year old BSC based crypto project. It aims to build financial instruments using Blockchain and Crypto Projects. They recently created a Payment Gateway for Ecommerce vendors to accept BNB, BUSD and SULFERC to there stores.